### PR TITLE
Improved window resizing behavior in coloring visualization

### DIFF
--- a/coloring/coloring.js
+++ b/coloring/coloring.js
@@ -149,8 +149,10 @@ function plotDegrees(minDegree, maxDegree, degreeCts) {
         .ticks(count);
 
     var svg = d3.select("#degreeHistogram").append("svg")
-        .attr("width", width)
+        .attr("width", "100%")
         .attr("height", height)
+        .attr("viewBox", "0 0 " + width + " " +height)
+        .attr("preserveAspectRatio","none")
         .append("g");
 
     var bar = svg.selectAll(".bar")
@@ -357,8 +359,6 @@ function vizBenchmark(){
         var canvas = document.getElementById('edgeCanvas');
         canvas.height = metadata.graphHeight;
         canvas.width = metadata.graphWidth;
-        canvas.style.left = document.getElementById('viz').offsetLeft + "px";
-        canvas.style.top = (document.getElementById('viz').offsetTop + PAD_ADJUST) + "px";
         
         var ctx = canvas.getContext('2d');
         ctx.strokeStyle = "rgba(0,0,0," + metadata.lineScale(edgeCt) + ")";

--- a/coloring/index.html
+++ b/coloring/index.html
@@ -42,9 +42,8 @@
     </div>
 	
     <div id="viz">
+        <canvas id="edgeCanvas"></canvas>
     </div>
-    
-    <canvas id="edgeCanvas"></canvas>
     
     <pre id="debug"></pre>
 

--- a/viz.css
+++ b/viz.css
@@ -45,11 +45,14 @@ SOFTWARE.
 
 #viz {
     padding-top: 15px;
+    width: 73%;
+    float: left;
+    position: relative; 
+    padding: 0;
+    margin: 15px 1%;
 }
 
 .svgMain {
-    margin-left: auto; 
-    margin-right: auto;
     display: block;
 }
 
@@ -85,12 +88,7 @@ SOFTWARE.
     padding: inherit 1% 0 1%;
     margin: 0 1% 0 0;
 }
-#viz {
-    width: 73%;
-    float: left;    
-    padding: inherit 1% 0 1%;
-    margin: 0;
-}
+
 .metadataTable { 
     width: 100%;
     border-collapse: collapse;


### PR DESCRIPTION
This fixes the problem in the coloring visualization where resizing the window moved the nodes away from their edges. I moved edgeCanvas inside the #viz div, and adjusted the CSS as necessary to position it. I did not see any adverse effects on the other visualizations. 

I also changed the degreeHistogram so that the svg resizes when the window resizes, preventing overlap between the graph and the data tables until the window gets very small.
